### PR TITLE
Run janitor

### DIFF
--- a/scripts/mitgcm-organize-run
+++ b/scripts/mitgcm-organize-run
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-# Assuming you have added scripts to you PATH already
+###
+# An example mitgcm run dir janitor script #
+###
+
+# How-to: Travel to your run dir, and run: 
+#   mitgcm-organize-run
+
+# Assuming you have added mv-mitgcm-* scripts to you PATH
 mv-mitgcm-grid
 mv-mitgcm-chkpt_state
 mv-mitgcm-pickup

--- a/scripts/mitgcm-organize-run
+++ b/scripts/mitgcm-organize-run
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Assuming you have added scripts to you PATH already
+mv-mitgcm-grid
+mv-mitgcm-chkpt_state
+mv-mitgcm-pickup

--- a/scripts/mv-mitgcm-chkpt_state
+++ b/scripts/mv-mitgcm-chkpt_state
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Check if a custom directory is provided
+if [ -z "$1" ]; then
+    echo "Move grid parameters to ./chkpt_state/"
+    dirname="chkpt_state"
+else
+    echo "Move grid parameters to user's directory: $1"
+    dirname=$1
+fi
+
+# Make grid directory
+mkdir -p "$dirname"
+
+# Move grid parameters
+mv -v Eta.*.[dm][ae]ta \
+PH.*.[dm][ae]ta \
+PHL.*.[dm][ae]ta \
+[STUVW].*.[dm][ae]ta \
+"$dirname"

--- a/scripts/mv-mitgcm-grid
+++ b/scripts/mv-mitgcm-grid
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check if a custom directory is provided
+if [ -z "$1" ]; then
+    echo "Move grid parameters to ./grid/"
+    dirname="grid"
+else
+    echo "Move grid parameters to user's directory: $1"
+    dirname=$1
+fi
+
+# Make grid directory
+mkdir -p "$dirname"
+
+# Move grid parameters
+mv -v [XY][CG].[dm][ae]ta \
+D[RXY][CF].[dm][ae]ta \
+D[XY][GUV].[dm][ae]ta \
+Depth.[dm][ae]ta \
+PHref[CF].[dm][ae]ta \
+RA[CSWZ].[dm][ae]ta \
+R[CF].[dm][ae]ta \
+RhoRef.[dm][ae]ta \
+hFac[CSW].[dm][ae]ta \
+Angle[CS][SN].[dm][ae]ta \
+maskCtrl[CSW]*.[dm][ae]ta \
+maskIn[CSW].[dm][ae]ta \
+[UV]2zonDir.[dm][ae]ta \
+"$dirname"

--- a/scripts/mv-mitgcm-pickup
+++ b/scripts/mv-mitgcm-pickup
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Check if a custom directory is provided
+if [ -z "$1" ]; then
+    echo "Move grid parameters to ./pickup/"
+    dirname="pickup"
+else
+    echo "Move grid parameters to user's directory: $1"
+    dirname=$1
+fi
+
+# Make grid directory
+mkdir -p "$dirname"
+
+# Move grid parameters
+mv -v pickup.*.[dm][ae]ta \
+"$dirname"


### PR DESCRIPTION
A run can generate a TON of files, making it hard to see all that you've simulated.

Here are scripts to move files into directories to clean-up your run directory:
- grid
- checkpoint states
- pickup 

User can optionally specify paths for each `mv-mitgcm-*` command. Default behavior is to create a directory inside the current run directory. Need to add script directory to your `$PATH`, and use **within** the run directory you are cleaning up!

Included a sample script for how to use `mv-mitgcm-*` with its default behavior: `mitgcm-organize-run`